### PR TITLE
Add GPG signing and remove GitHub registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,17 @@ jobs:
         uses: actions/setup-go@v2
         with: { go-version: 1.18 }
 
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: paultyng/ghaction-import-gpg@v2.1.0
-      #   env:
-      #     GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      #     PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      # - name: Export GPG public key
-      #   run: |
-      #     echo ${{ steps.import_gpg.outputs.fingerprint }} > key.fingerprint
-      #     gpg --armor --export ${{ steps.import_gpg.outputs.keyid }} > key.asc
+      - name: Export GPG public key
+        run: |
+          echo ${{ steps.import_gpg.outputs.fingerprint }} > key.fingerprint
+          gpg --armor --export ${{ steps.import_gpg.outputs.keyid }} > key.asc
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -36,8 +36,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          # Uncomment GPG_FINGERPRINT after adding the secret to the repo
-          # GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser (no publish)
@@ -49,8 +48,7 @@ jobs:
           version: latest
           args: build --rm-dist --snapshot
         env:
-          # Uncomment GPG_FINGERPRINT after adding the secret to the repo
-          # GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive artifacts for use in Docker build
@@ -100,14 +98,6 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
         run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
-      - name: Log in to GitHub registry
-        if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -119,5 +109,3 @@ jobs:
           tags: |
             ${{ secrets.PUBLIC_PROMETHEUS_EXPORTER_ECR_REPOSITORY_URL }}:${{ github.ref == 'refs/heads/main' && 'future' || 'latest' }}
             ${{ startsWith(github.ref, 'refs/tags/v') && format('{0}:{1}', secrets.PUBLIC_PROMETHEUS_EXPORTER_ECR_REPOSITORY_URL, github.ref_name) || '' }}
-            ghcr.io/spacelift-io/prometheus-exporter:${{ github.ref == 'refs/heads/main' && 'future' || 'latest' }}
-            ${{ startsWith(github.ref, 'refs/tags/v') && format('ghcr.io/spacelift-io/prometheus-exporter:{0}', github.ref_name) || '' }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,17 +27,16 @@ checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
 
-# Re-add this once we have the correct GPG secrets added to the repo
-# signs:
-#   - artifacts: checksum
-#     args:
-#       - "--batch"
-#       - "--local-user"
-#       - "{{ .Env.GPG_FINGERPRINT }}"
-#       - "--output"
-#       - "${signature}"
-#       - "--detach-sign"
-#       - "${artifact}"
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
 
 release:
   draft: false


### PR DESCRIPTION
- Updated the release pipeline and goreleaser config to sign the binaries using GPG.
- Removed the publish to the GitHub registry. It's not required for this repo and just adds unnecessary complication right now.