### PR TITLE
Re-authenticate after an unauthorized response

### DIFF
--- a/client/session/api_key.go
+++ b/client/session/api_key.go
@@ -44,6 +44,10 @@ func (g *apiKey) BearerToken(ctx context.Context) (string, error) {
 	return g.apiToken.BearerToken(ctx)
 }
 
+func (g *apiKey) RefreshToken(ctx context.Context) error {
+	return g.exchange(ctx)
+}
+
 func (g *apiKey) exchange(ctx context.Context) error {
 	var mutation struct {
 		APIKeyUser user `graphql:"apiKeyUser(id: $id, secret: $secret)"`

--- a/client/session/interface.go
+++ b/client/session/interface.go
@@ -10,6 +10,7 @@ import (
 type Session interface {
 	BearerToken(ctx context.Context) (string, error)
 	Endpoint() string
+	RefreshToken(ctx context.Context) error
 }
 
 // Must provides a helper that either creates a Session or dies trying.


### PR DESCRIPTION
If an unauthorized response is received from the server, we'll now retry the request. This handles the situation where the session is removed or a login policy is updated, and the exporter can no-longer make requests.

Unfortunately the GraphQL returns a 200 for unauthorized responses, so we need to look at the error text.

Issue: #10