### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ The following metrics are provided by the exporter:
 | `spacelift_current_billing_period_used_private_seconds`    |                                      | The amount of private worker usage in the current billing period                               |
 | `spacelift_current_billing_period_used_public_seconds`     |                                      | The amount of public worker usage in the current billing period                                |
 | `spacelift_current_billing_period_used_seats`              |                                      | The number of seats used in the current billing period                                         |
-| `spacelift_current_billing_period_used_private_workers`    |                                      | The number of private workers used in the current billing period                               |
 | `spacelift_scrape_duration`                                |                                      | The duration in seconds of the request to the Spacelift API for metrics                        |
 | `spacelift_build_info`                                     |                                      | Contains build information about the exporter (version, commit, etc)                           |
 


### PR DESCRIPTION
removing "spacelift_current_billing_period_used_private_workers" as it is no longer supported 