### PR TITLE
ci: split build and release actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  goreleaser:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with: { go-version-file: go.mod }
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean --snapshot --skip sign
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: "public.ecr.aws/spacelift/promex:pr-build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
-on: { push }
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
 
 jobs:
   goreleaser:


### PR DESCRIPTION
The problem is that Dependabot can't access GitHub action secrets, so the release workflow is failing. Since we don't really need to do parts of the release workflow as part of a PR check, I've split it into two workflows:

- Build - just builds using GoReleaser and builds the Docker image.
- Release - the same as before, but only runs on pushes to `main` or `v*` tag pushes.