### PR TITLE
Fix failing GitHub Action release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,6 @@ jobs:
           name: dist
           path: dist
 
-      - name: Install the latest AWS CLI
-        if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
-        run: |
-          apk add --no-cache python3 py3-pip
-          pip3 install --upgrade pip
-          pip3 install awscli
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
The release job is failing currently: https://github.com/spacelift-io/prometheus-exporter/actions/runs/7976279571/job/21776500696