### PR TITLE
chore: include client type in the header of graphql requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,7 +33,7 @@ func (c *client) Query(ctx context.Context, query interface{}, variables map[str
 		req.Header.Add("Spacelift-Client-Type", "prometheus-exporter")
 	})
 
-	err = apiClient.Query(ctx, query, variables)
+	err = apiClient.Query(ctx, query, variables, graphql.OperationName("PrometheusExporter"))
 	if err != nil && strings.Contains(err.Error(), "unauthorized") {
 		logger.Warn("Server returned an unauthorized response - retrying request with a new token")
 		c.session.RefreshToken(ctx)

--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,10 @@ func (c *client) Query(ctx context.Context, query interface{}, variables map[str
 		return err
 	}
 
+	apiClient.WithRequestModifier(func(req *http.Request) {
+		req.Header.Add("Spacelift-Client-Type", "prometheus-exporter")
+	})
+
 	err = apiClient.Query(ctx, query, variables)
 	if err != nil && strings.Contains(err.Error(), "unauthorized") {
 		logger.Warn("Server returned an unauthorized response - retrying request with a new token")


### PR DESCRIPTION
There's 2 changes in this PR, each in a separate commit:
- add a header indicating a client type
- use a named query

Here's a trace before the query was named:

<img width="771" alt="Screenshot 2024-07-11 at 17 31 56" src="https://github.com/spacelift-io/prometheus-exporter/assets/12897831/403b6819-82b0-4ba9-b359-c3e971eb4264">


and after using a named query:

<img width="753" alt="Screenshot 2024-07-11 at 17 31 20" src="https://github.com/spacelift-io/prometheus-exporter/assets/12897831/7e197881-ed52-4c23-92a5-26093c7c22a8">

see the linked issue for more details