### PR TITLE
feat: added metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,8 @@
 
 # options for analysis running
 run:
+  # go version
+  go: "1.22"
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
 
@@ -11,22 +13,24 @@ run:
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
+issues:
+  exclude-dirs-use-default: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
 
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
   # default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
 
   # print linter name in the end of issue text, default is true
   print-linter-name: true
-
-  # make issues output unique by line, default is true
-  uniq-by-line: true
 
   # add a prefix to the output file references; default is no prefix
   path-prefix: ""
@@ -49,7 +53,6 @@ linters-settings:
     min-len: 2
     min-occurrences: 2
   staticcheck:
-    go: "1.18"
     checks: ["all", "-SA1019"]
   gocritic:
     enabled-tags:
@@ -72,10 +75,8 @@ linters-settings:
       - preferFprint
   goimports:
     local-prefixes: github.com/spacelift-io/prometheus-exporter
-  govet:
-    check-shadowing: false
+
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
   depguard:
@@ -90,7 +91,7 @@ linters:
   disable-all: true
   enable:
     - depguard
-    - exportloopref
+    - copyloopvar
     - gci
     - gocritic
     - gofmt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+# stage #1
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o spacelift-promex .
+
+
+# stage #2
+FROM alpine:3.19
+EXPOSE 9953
+
+RUN apk add --no-cache ca-certificates
+RUN apk upgrade --update-cache --available
+RUN adduser --disabled-password --no-create-home --uid=1983 spacelift
+
+COPY --from=builder /app/spacelift-promex /usr/bin/spacelift-promex
+RUN chmod +x /usr/bin/spacelift-promex
+
+CMD ["/usr/bin/spacelift-promex", "serve"]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ The following metrics are provided by the exporter:
 | `spacelift_current_billing_period_used_private_seconds`    |                                      | The amount of private worker usage in the current billing period                               |
 | `spacelift_current_billing_period_used_public_seconds`     |                                      | The amount of public worker usage in the current billing period                                |
 | `spacelift_current_billing_period_used_seats`              |                                      | The number of seats used in the current billing period                                         |
+| `spacelift_current_stacks_count_by_state`                  |                                      | The number of stacks by certain stacks                                                         |
+| `spacelift_current_resources_count_by_drift`                |                                      | The number of resources by drift                                                               |
+| `spacelift_current_avg_stack_size_by_resource_count`       |                                      | The average stack size by resource count                                                      |
+| `spacelift_current_average_run_duration`                   |                                      | The average run duration                                                                       |
+| `spacelift_current_median_run_duration`                    |                                      | The median run duration                                                                        |
 | `spacelift_scrape_duration`                                |                                      | The duration in seconds of the request to the Spacelift API for metrics                        |
 | `spacelift_build_info`                                     |                                      | Contains build information about the exporter (version, commit, etc)                           |
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ The following metrics are provided by the exporter:
 | `spacelift_current_billing_period_used_private_seconds`    |                                      | The amount of private worker usage in the current billing period                               |
 | `spacelift_current_billing_period_used_public_seconds`     |                                      | The amount of public worker usage in the current billing period                                |
 | `spacelift_current_billing_period_used_seats`              |                                      | The number of seats used in the current billing period                                         |
-| `spacelift_current_stacks_count_by_state`                  |                                      | The number of stacks by certain stacks                                                         |
-| `spacelift_current_resources_count_by_drift`                |                                      | The number of resources by drift                                                               |
-| `spacelift_current_avg_stack_size_by_resource_count`       |                                      | The average stack size by resource count                                                      |
+| `spacelift_current_stacks_count_by_state`                  | `state`                              | The number of stacks grouped by state                                                          |
+| `spacelift_current_resources_count_by_drift`               | `state`                              | The number of resources by drift                                                               |
+| `spacelift_current_avg_stack_size_by_resource_count`       |                                      | The average stack size by resource count                                                       |
 | `spacelift_current_average_run_duration`                   |                                      | The average run duration                                                                       |
 | `spacelift_current_median_run_duration`                    |                                      | The median run duration                                                                        |
 | `spacelift_scrape_duration`                                |                                      | The duration in seconds of the request to the Spacelift API for metrics                        |

--- a/collector.go
+++ b/collector.go
@@ -8,11 +8,10 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
-
 	"github.com/spacelift-io/prometheus-exporter/client"
 	"github.com/spacelift-io/prometheus-exporter/client/session"
 	"github.com/spacelift-io/prometheus-exporter/logging"
+	"go.uber.org/zap"
 )
 
 type spaceliftCollector struct {
@@ -171,8 +170,8 @@ func (c *spaceliftCollector) Describe(descriptorChannel chan<- *prometheus.Desc)
 }
 
 type dataPoint struct {
-	Value    float64
-	Labels   []string
+	Value  float64
+	Labels []string
 }
 
 type metricsQuery struct {
@@ -199,11 +198,11 @@ type metricsQuery struct {
 		UsedSeats          int `graphql:"usedSeats"`
 	} `graphql:"usage"`
 	Metrics struct {
-		StacksCountByState []dataPoint `graphql:"stacksCountByState"`
-		ResourcesCountByDrift []dataPoint `graphql:"resourcesCountByDrift"`
+		StacksCountByState          []dataPoint `graphql:"stacksCountByState"`
+		ResourcesCountByDrift       []dataPoint `graphql:"resourcesCountByDrift"`
 		AvgStackSizeByResourceCount []dataPoint `graphql:"avgStackSizeByResourceCount"`
-		AverageRunDuration []dataPoint `graphql:"averageRunDuration"`
-		MedianRunDuration []dataPoint `graphql:"medianRunDuration"`
+		AverageRunDuration          []dataPoint `graphql:"averageRunDuration"`
+		MedianRunDuration           []dataPoint `graphql:"medianRunDuration"`
 	} `graphql:"metrics"`
 }
 
@@ -253,21 +252,21 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 			metricChannel <- prometheus.MustNewConstMetric(c.currentStacksCountByState, prometheus.GaugeValue, state.Value, state.Labels[0])
 		}
 	}
-	
+
 	for _, state := range query.Metrics.ResourcesCountByDrift {
 		if len(state.Labels) > 0 {
 			metricChannel <- prometheus.MustNewConstMetric(c.currentResourcesCountByDrift, prometheus.GaugeValue, state.Value, state.Labels[0])
 		}
 	}
-	
+
 	if len(query.Metrics.AvgStackSizeByResourceCount) > 0 {
 		metricChannel <- prometheus.MustNewConstMetric(c.currentAvgStackSizeByResourceCount, prometheus.GaugeValue, query.Metrics.AvgStackSizeByResourceCount[0].Value)
 	}
-	
+
 	if len(query.Metrics.AverageRunDuration) > 0 {
 		metricChannel <- prometheus.MustNewConstMetric(c.currentAverageRunDuration, prometheus.GaugeValue, query.Metrics.AverageRunDuration[0].Value)
 	}
-	
+
 	if len(query.Metrics.MedianRunDuration) > 0 {
 		metricChannel <- prometheus.MustNewConstMetric(c.currentMedianRunDuration, prometheus.GaugeValue, query.Metrics.MedianRunDuration[0].Value)
 	}

--- a/collector.go
+++ b/collector.go
@@ -249,16 +249,28 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedSeats, prometheus.GaugeValue, float64(query.Usage.UsedSeats))
 
 	for _, state := range query.Metrics.StacksCountByState {
-		metricChannel <- prometheus.MustNewConstMetric(c.currentStacksCountByState, prometheus.GaugeValue, state.Value, state.Labels[0])
-	}
-
-	for _, state := range query.Metrics.ResourcesCountByDrift {
-		metricChannel <- prometheus.MustNewConstMetric(c.currentResourcesCountByDrift, prometheus.GaugeValue, state.Value, state.Labels[0])
+		if len(state.Labels) > 0 {
+			metricChannel <- prometheus.MustNewConstMetric(c.currentStacksCountByState, prometheus.GaugeValue, state.Value, state.Labels[0])
+		}
 	}
 	
-	metricChannel <- prometheus.MustNewConstMetric(c.currentAvgStackSizeByResourceCount, prometheus.GaugeValue, float64(query.Metrics.AvgStackSizeByResourceCount[0].Value))
-	metricChannel <- prometheus.MustNewConstMetric(c.currentAverageRunDuration, prometheus.GaugeValue, float64(query.Metrics.AverageRunDuration[0].Value))
-	metricChannel <- prometheus.MustNewConstMetric(c.currentMedianRunDuration, prometheus.GaugeValue, float64(query.Metrics.MedianRunDuration[0].Value))
+	for _, state := range query.Metrics.ResourcesCountByDrift {
+		if len(state.Labels) > 0 {
+			metricChannel <- prometheus.MustNewConstMetric(c.currentResourcesCountByDrift, prometheus.GaugeValue, state.Value, state.Labels[0])
+		}
+	}
+	
+	if len(query.Metrics.AvgStackSizeByResourceCount) > 0 {
+		metricChannel <- prometheus.MustNewConstMetric(c.currentAvgStackSizeByResourceCount, prometheus.GaugeValue, query.Metrics.AvgStackSizeByResourceCount[0].Value)
+	}
+	
+	if len(query.Metrics.AverageRunDuration) > 0 {
+		metricChannel <- prometheus.MustNewConstMetric(c.currentAverageRunDuration, prometheus.GaugeValue, query.Metrics.AverageRunDuration[0].Value)
+	}
+	
+	if len(query.Metrics.MedianRunDuration) > 0 {
+		metricChannel <- prometheus.MustNewConstMetric(c.currentMedianRunDuration, prometheus.GaugeValue, query.Metrics.MedianRunDuration[0].Value)
+	}
 
 	for _, workerPool := range query.WorkerPools {
 		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolRunsPending, prometheus.GaugeValue, float64(workerPool.PendingRuns), workerPool.ID, workerPool.Name)

--- a/collector.go
+++ b/collector.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"runtime/debug"
-	"time"
+    "context"
+    "errors"
+    "net/http"
+    "runtime/debug"
+    "time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spacelift-io/prometheus-exporter/client"
-	"github.com/spacelift-io/prometheus-exporter/client/session"
-	"github.com/spacelift-io/prometheus-exporter/logging"
-	"go.uber.org/zap"
+    "github.com/prometheus/client_golang/prometheus"
+    "go.uber.org/zap"
+
+    "github.com/spacelift-io/prometheus-exporter/client"
+    "github.com/spacelift-io/prometheus-exporter/client/session"
+    "github.com.spacelift-io/prometheus-exporter/logging"
 )
 
 type spaceliftCollector struct {

--- a/collector.go
+++ b/collector.go
@@ -32,6 +32,11 @@ type spaceliftCollector struct {
 	currentBillingPeriodUsedPrivateSeconds *prometheus.Desc
 	currentBillingPeriodUsedPublicSeconds  *prometheus.Desc
 	currentBillingPeriodUsedSeats          *prometheus.Desc
+	currentStacksCountByState              *prometheus.Desc
+	currentResourcesCountByDrift           *prometheus.Desc
+	currentAvgStackSizeByResourceCount     *prometheus.Desc
+	currentAverageRunDuration              *prometheus.Desc
+	currentMedianRunDuration               *prometheus.Desc
 	scrapeDuration                         *prometheus.Desc
 	buildInfo                              *prometheus.Desc
 }
@@ -107,6 +112,31 @@ func newSpaceliftCollector(ctx context.Context, httpClient *http.Client, session
 			"The number of seats used in the current billing period",
 			nil,
 			nil),
+		currentStacksCountByState: prometheus.NewDesc(
+			"spacelift_current_stacks_count_by_state",
+			"The number of stacks by certain stacks",
+			[]string{"state"},
+			nil),
+		currentResourcesCountByDrift: prometheus.NewDesc(
+			"spacelift_current_resources_count_by_drift",
+			"The number of drifted resources",
+			[]string{"state"},
+			nil),
+		currentAvgStackSizeByResourceCount : prometheus.NewDesc(
+			"spacelift_current_avg_stack_size_by_resource_count",
+			"The average stack size by resource count",
+			nil,
+			nil),
+		currentAverageRunDuration : prometheus.NewDesc(
+			"spacelift_current_average_run_duration",
+			"The average run duration",
+			nil,
+			nil),
+		currentMedianRunDuration : prometheus.NewDesc(
+			"spacelift_current_median_run_duration",
+			"The median run duration",
+			nil,
+			nil),
 		scrapeDuration: prometheus.NewDesc(
 			"spacelift_scrape_duration_seconds",
 			"The duration in seconds of the request to the Spacelift API for metrics",
@@ -132,7 +162,17 @@ func (c *spaceliftCollector) Describe(descriptorChannel chan<- *prometheus.Desc)
 	descriptorChannel <- c.currentBillingPeriodUsedPrivateSeconds
 	descriptorChannel <- c.currentBillingPeriodUsedPublicSeconds
 	descriptorChannel <- c.currentBillingPeriodUsedSeats
+	descriptorChannel <- c.currentStacksCountByState
+	descriptorChannel <- c.currentResourcesCountByDrift
+	descriptorChannel <- c.currentAvgStackSizeByResourceCount
+	descriptorChannel <- c.currentAverageRunDuration
+	descriptorChannel <- c.currentMedianRunDuration
 	descriptorChannel <- c.buildInfo
+}
+
+type dataPoint struct {
+	Value    float64
+	Labels   []string
 }
 
 type metricsQuery struct {
@@ -158,6 +198,13 @@ type metricsQuery struct {
 		UsedPublicMinutes  int `graphql:"usedPublicMinutes"`
 		UsedSeats          int `graphql:"usedSeats"`
 	} `graphql:"usage"`
+	Metrics struct {
+		StacksCountByState []dataPoint `graphql:"stacksCountByState"`
+		ResourcesCountByDrift []dataPoint `graphql:"resourcesCountByDrift"`
+		AvgStackSizeByResourceCount []dataPoint `graphql:"avgStackSizeByResourceCount"`
+		AverageRunDuration []dataPoint `graphql:"averageRunDuration"`
+		MedianRunDuration []dataPoint `graphql:"medianRunDuration"`
+	} `graphql:"metrics"`
 }
 
 func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
@@ -200,6 +247,18 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedPrivateSeconds, prometheus.GaugeValue, float64(query.Usage.UsedPrivateMinutes*60))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedPublicSeconds, prometheus.GaugeValue, float64(query.Usage.UsedPublicMinutes*60))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedSeats, prometheus.GaugeValue, float64(query.Usage.UsedSeats))
+
+	for _, state := range query.Metrics.StacksCountByState {
+		metricChannel <- prometheus.MustNewConstMetric(c.currentStacksCountByState, prometheus.GaugeValue, state.Value, state.Labels[0])
+	}
+
+	for _, state := range query.Metrics.ResourcesCountByDrift {
+		metricChannel <- prometheus.MustNewConstMetric(c.currentResourcesCountByDrift, prometheus.GaugeValue, state.Value, state.Labels[0])
+	}
+	
+	metricChannel <- prometheus.MustNewConstMetric(c.currentAvgStackSizeByResourceCount, prometheus.GaugeValue, float64(query.Metrics.AvgStackSizeByResourceCount[0].Value))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentAverageRunDuration, prometheus.GaugeValue, float64(query.Metrics.AverageRunDuration[0].Value))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentMedianRunDuration, prometheus.GaugeValue, float64(query.Metrics.MedianRunDuration[0].Value))
 
 	for _, workerPool := range query.WorkerPools {
 		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolRunsPending, prometheus.GaugeValue, float64(workerPool.PendingRuns), workerPool.ID, workerPool.Name)

--- a/collector.go
+++ b/collector.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-    "context"
-    "errors"
-    "net/http"
-    "runtime/debug"
-    "time"
+	"context"
+	"errors"
+	"net/http"
+	"runtime/debug"
+	"time"
 
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/spacelift-io/prometheus-exporter/client"
-    "github.com/spacelift-io/prometheus-exporter/client/session"
-    "github.com/spacelift-io/prometheus-exporter/logging"
-    "go.uber.org/zap"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/spacelift-io/prometheus-exporter/client"
+	"github.com/spacelift-io/prometheus-exporter/client/session"
+	"github.com/spacelift-io/prometheus-exporter/logging"
 )
 
 type spaceliftCollector struct {

--- a/collector.go
+++ b/collector.go
@@ -8,11 +8,10 @@ import (
     "time"
 
     "github.com/prometheus/client_golang/prometheus"
-    "go.uber.org/zap"
-
     "github.com/spacelift-io/prometheus-exporter/client"
     "github.com/spacelift-io/prometheus-exporter/client/session"
-    "github.com.spacelift-io/prometheus-exporter/logging"
+    "github.com/spacelift-io/prometheus-exporter/logging"
+    "go.uber.org/zap"
 )
 
 type spaceliftCollector struct {

--- a/collector.go
+++ b/collector.go
@@ -122,17 +122,17 @@ func newSpaceliftCollector(ctx context.Context, httpClient *http.Client, session
 			"The number of drifted resources",
 			[]string{"state"},
 			nil),
-		currentAvgStackSizeByResourceCount : prometheus.NewDesc(
+		currentAvgStackSizeByResourceCount: prometheus.NewDesc(
 			"spacelift_current_avg_stack_size_by_resource_count",
 			"The average stack size by resource count",
 			nil,
 			nil),
-		currentAverageRunDuration : prometheus.NewDesc(
+		currentAverageRunDuration: prometheus.NewDesc(
 			"spacelift_current_average_run_duration",
 			"The average run duration",
 			nil,
 			nil),
-		currentMedianRunDuration : prometheus.NewDesc(
+		currentMedianRunDuration: prometheus.NewDesc(
 			"spacelift_current_median_run_duration",
 			"The median run duration",
 			nil,

--- a/collector.go
+++ b/collector.go
@@ -114,7 +114,7 @@ func newSpaceliftCollector(ctx context.Context, httpClient *http.Client, session
 			nil),
 		currentStacksCountByState: prometheus.NewDesc(
 			"spacelift_current_stacks_count_by_state",
-			"The number of stacks by certain stacks",
+			"The number of stacks grouped by state",
 			[]string{"state"},
 			nil),
 		currentResourcesCountByDrift: prometheus.NewDesc(


### PR DESCRIPTION
Added metrics:
 * `spacelift_current_stacks_count_by_state` - The number of stacks grouped by state(FAILED/FINISHED/UNCONFIRMED)
 * `spacelift_current_resources_count_by_drift` - The number of drifted resources by state (drifted/health)
 * `spacelift_current_avg_stack_size_by_resource_count` - The average stack size by resource count
 * `spacelift_current_average_run_duration` - The average run duration"
 * `spacelift_current_median_run_duration` - The median run duration


Reference:
 * metrics [graphql](https://graphdoc.io/preview/query/metrics?endpoint=https://demo.app.spacelift.io/graphql) endpoint