### PR TITLE
chore(goreleaser): fix deprecated fields

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,11 +18,11 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"


### PR DESCRIPTION
Fixes the deprecation warnings: https://goreleaser.com/deprecations/#archivesformat_overridesformat