### PR TITLE
chore(ci): pin GoReleaser to v2.14.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "v2.14.3"
           args: release --clean --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
## Summary

Newer GoReleaser versions break GPG signing of release artifacts (goreleaser/goreleaser#6514). Pin to the last known good version (v2.14.3) to prevent broken signatures on the next release.

Same fix as spacelift-io/spacectl#408 and spacelift-io/terraform-provider-spacelift#772.