### PR TITLE
feat: expand /metrics with point-in-time Spacelift parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .env
 node_modules
-
+.mcp.json
+bakes/*
+fast.yaml
 dist/
 
 # Ignore GPG public keys produced during release process, otherwise goreleaser fails because

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .env
 node_modules
-.mcp.json
-bakes/*
-fast.yaml
 dist/
 
 # Ignore GPG public keys produced during release process, otherwise goreleaser fails because

--- a/README.md
+++ b/README.md
@@ -186,8 +186,35 @@ The following metrics are provided by the exporter:
 | `spacelift_current_stacks_count_by_state`                  | `state`                              | The number of stacks grouped by state                                                          |
 | `spacelift_current_resources_count_by_drift`               | `state`                              | The number of resources by drift                                                               |
 | `spacelift_current_avg_stack_size_by_resource_count`       |                                      | The average stack size by resource count                                                       |
+| `spacelift_current_max_stack_size_by_resource_count`       |                                      | The maximum stack size by resource count                                                       |
 | `spacelift_current_average_run_duration`                   |                                      | The average run duration                                                                       |
 | `spacelift_current_median_run_duration`                    |                                      | The median run duration                                                                        |
+| `spacelift_current_drift_detection_coverage`               |                                      | Drift detection coverage across stacks                                                         |
+| `spacelift_current_resources_count_by_vendor`              | `vendor`                             | The number of resources grouped by vendor                                                      |
+| `spacelift_current_has_stacks`                             |                                      | Whether the account has any stacks (1) or not (0)                                              |
+| `spacelift_current_has_runs`                               |                                      | Whether the account has any runs (1) or not (0)                                                |
+| `spacelift_public_worker_pool_users`                       |                                      | The number of stacks/modules using the public worker pool                                      |
+| `spacelift_public_worker_pool_intent_projects`             |                                      | The number of intent projects using the public worker pool                                     |
+| `spacelift_public_worker_pool_runs_schedulable`            |                                      | The number of schedulable runs on the public worker pool for this account                      |
+| `spacelift_worker_pool_runs_schedulable`                   | `worker_pool_id`, `worker_pool_name` | The number of schedulable runs on a worker pool                                                |
+| `spacelift_worker_pool_users`                              | `worker_pool_id`, `worker_pool_name` | The number of stacks/modules using a worker pool                                               |
+| `spacelift_worker_pool_notifications`                      | `worker_pool_id`, `worker_pool_name` | The number of new notifications on a worker pool                                               |
+| `spacelift_worker_pool_intent_projects`                    | `worker_pool_id`, `worker_pool_name` | The number of intent projects using a worker pool                                              |
+| `spacelift_worker_pool_drift_detection_run_limit`          | `worker_pool_id`, `worker_pool_name` | Maximum drift detection runs that can be scheduled on a worker pool (negative = no limit)      |
+| `spacelift_worker_pool_managed_by_k8s_controller`          | `worker_pool_id`, `worker_pool_name` | Whether a worker pool is managed by the Kubernetes WorkerPool controller (1) or not (0)        |
+| `spacelift_current_billing_period_allowed_seconds`         |                                      | The number of seconds that can be used within the current billing period                       |
+| `spacelift_current_billing_period_allowed_seats`           |                                      | The number of seats allowed within the current billing period                                  |
+| `spacelift_current_billing_period_used_seconds`            |                                      | The total amount of worker usage in the current billing period                                 |
+| `spacelift_current_billing_period_used_workers`            |                                      | Maximum number of concurrent self-hosted workers in the current billing period                 |
+| `spacelift_seats_limit`                                    | `type`                               | The total number of seats available (-1 means unlimited)                                       |
+| `spacelift_seats_in_use`                                   | `type`                               | The number of seats currently in use                                                           |
+| `spacelift_integrations_count`                             | `integration`                        | The number of integrations grouped by type                                                     |
+| `spacelift_audit_trail_retention_days`                     |                                      | How many days built-in audit trails are stored                                                 |
+| `spacelift_run_log_retention_days`                         |                                      | How many days run logs are retained                                                            |
+| `spacelift_largest_stack_resources`                        | `stack_slug`, `stack_name`, `stack_state` | Resource count for each of the largest stacks (top-N as returned by the API)              |
+| `spacelift_runs_needing_approval`                          |                                      | The number of runs currently needing approval                                                  |
+| `spacelift_runs_requiring_attention`                       |                                      | The number of runs requiring attention                                                         |
+| `spacelift_drift_detection_schedules_upcoming`             |                                      | The number of upcoming drift detection schedules                                               |
 | `spacelift_scrape_duration`                                |                                      | The duration in seconds of the request to the Spacelift API for metrics                        |
 | `spacelift_build_info`                                     |                                      | Contains build information about the exporter (version, commit, etc)                           |
 

--- a/collector.go
+++ b/collector.go
@@ -35,8 +35,35 @@ type spaceliftCollector struct {
 	currentStacksCountByState              *prometheus.Desc
 	currentResourcesCountByDrift           *prometheus.Desc
 	currentAvgStackSizeByResourceCount     *prometheus.Desc
+	currentMaxStackSizeByResourceCount     *prometheus.Desc
 	currentAverageRunDuration              *prometheus.Desc
 	currentMedianRunDuration               *prometheus.Desc
+	currentDriftDetectionCoverage          *prometheus.Desc
+	currentResourcesCountByVendor          *prometheus.Desc
+	currentHasStacks                       *prometheus.Desc
+	currentHasRuns                         *prometheus.Desc
+	publicUsers                            *prometheus.Desc
+	publicIntentProjects                   *prometheus.Desc
+	publicRunsSchedulable                  *prometheus.Desc
+	workerPoolRunsSchedulable              *prometheus.Desc
+	workerPoolUsers                        *prometheus.Desc
+	workerPoolNotifications                *prometheus.Desc
+	workerPoolIntentProjects               *prometheus.Desc
+	workerPoolDriftDetectionRunLimit       *prometheus.Desc
+	workerPoolManagedByK8sController       *prometheus.Desc
+	currentBillingPeriodAllowedSeconds     *prometheus.Desc
+	currentBillingPeriodAllowedSeats       *prometheus.Desc
+	currentBillingPeriodUsedSeconds        *prometheus.Desc
+	currentBillingPeriodUsedWorkers        *prometheus.Desc
+	seatsLimit                             *prometheus.Desc
+	seatsInUse                             *prometheus.Desc
+	integrationsCount                      *prometheus.Desc
+	auditTrailRetentionDays                *prometheus.Desc
+	runLogRetentionDays                    *prometheus.Desc
+	largestStackResources                  *prometheus.Desc
+	runsNeedingApproval                    *prometheus.Desc
+	runsRequiringAttention                 *prometheus.Desc
+	driftDetectionSchedulesUpcoming        *prometheus.Desc
 	scrapeDuration                         *prometheus.Desc
 	buildInfo                              *prometheus.Desc
 }
@@ -137,6 +164,141 @@ func newSpaceliftCollector(ctx context.Context, httpClient *http.Client, session
 			"The median run duration",
 			nil,
 			nil),
+		currentMaxStackSizeByResourceCount: prometheus.NewDesc(
+			"spacelift_current_max_stack_size_by_resource_count",
+			"The maximum stack size by resource count",
+			nil,
+			nil),
+		currentDriftDetectionCoverage: prometheus.NewDesc(
+			"spacelift_current_drift_detection_coverage",
+			"Drift detection coverage across stacks",
+			nil,
+			nil),
+		currentResourcesCountByVendor: prometheus.NewDesc(
+			"spacelift_current_resources_count_by_vendor",
+			"The number of resources grouped by vendor",
+			[]string{"vendor"},
+			nil),
+		currentHasStacks: prometheus.NewDesc(
+			"spacelift_current_has_stacks",
+			"Whether the account has any stacks (1) or not (0)",
+			nil,
+			nil),
+		currentHasRuns: prometheus.NewDesc(
+			"spacelift_current_has_runs",
+			"Whether the account has any runs (1) or not (0)",
+			nil,
+			nil),
+		publicUsers: prometheus.NewDesc(
+			"spacelift_public_worker_pool_users",
+			"The number of stacks/modules using the public worker pool",
+			nil,
+			nil),
+		publicIntentProjects: prometheus.NewDesc(
+			"spacelift_public_worker_pool_intent_projects",
+			"The number of intent projects using the public worker pool",
+			nil,
+			nil),
+		publicRunsSchedulable: prometheus.NewDesc(
+			"spacelift_public_worker_pool_runs_schedulable",
+			"The number of schedulable runs on the public worker pool for this account",
+			nil,
+			nil),
+		workerPoolRunsSchedulable: prometheus.NewDesc(
+			"spacelift_worker_pool_runs_schedulable",
+			"The number of schedulable runs on a worker pool",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		workerPoolUsers: prometheus.NewDesc(
+			"spacelift_worker_pool_users",
+			"The number of stacks/modules using a worker pool",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		workerPoolNotifications: prometheus.NewDesc(
+			"spacelift_worker_pool_notifications",
+			"The number of new notifications on a worker pool",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		workerPoolIntentProjects: prometheus.NewDesc(
+			"spacelift_worker_pool_intent_projects",
+			"The number of intent projects using a worker pool",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		workerPoolDriftDetectionRunLimit: prometheus.NewDesc(
+			"spacelift_worker_pool_drift_detection_run_limit",
+			"Maximum number of drift detection runs that can be scheduled on a worker pool. Negative values mean no limit; not emitted when unset",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		workerPoolManagedByK8sController: prometheus.NewDesc(
+			"spacelift_worker_pool_managed_by_k8s_controller",
+			"Whether a worker pool is managed by the Kubernetes WorkerPool controller (1) or not (0)",
+			[]string{"worker_pool_id", "worker_pool_name"},
+			nil),
+		currentBillingPeriodAllowedSeconds: prometheus.NewDesc(
+			"spacelift_current_billing_period_allowed_seconds",
+			"The number of seconds that can be used within the current billing period",
+			nil,
+			nil),
+		currentBillingPeriodAllowedSeats: prometheus.NewDesc(
+			"spacelift_current_billing_period_allowed_seats",
+			"The number of seats allowed within the current billing period",
+			nil,
+			nil),
+		currentBillingPeriodUsedSeconds: prometheus.NewDesc(
+			"spacelift_current_billing_period_used_seconds",
+			"The total amount of worker usage in the current billing period",
+			nil,
+			nil),
+		currentBillingPeriodUsedWorkers: prometheus.NewDesc(
+			"spacelift_current_billing_period_used_workers",
+			"Maximum number of concurrent self-hosted workers in the current billing period",
+			nil,
+			nil),
+		seatsLimit: prometheus.NewDesc(
+			"spacelift_seats_limit",
+			"The total number of seats available; -1 means unlimited",
+			[]string{"type"},
+			nil),
+		seatsInUse: prometheus.NewDesc(
+			"spacelift_seats_in_use",
+			"The number of seats currently in use (instantaneous; cf. spacelift_current_billing_period_used_seats which is billing-period scoped)",
+			[]string{"type"},
+			nil),
+		integrationsCount: prometheus.NewDesc(
+			"spacelift_integrations_count",
+			"The number of integrations grouped by type",
+			[]string{"integration"},
+			nil),
+		auditTrailRetentionDays: prometheus.NewDesc(
+			"spacelift_audit_trail_retention_days",
+			"How many days built-in audit trails are stored",
+			nil,
+			nil),
+		runLogRetentionDays: prometheus.NewDesc(
+			"spacelift_run_log_retention_days",
+			"How many days run logs are retained",
+			nil,
+			nil),
+		largestStackResources: prometheus.NewDesc(
+			"spacelift_largest_stack_resources",
+			"Resource count for each of the account's largest stacks (top-N as returned by the API)",
+			[]string{"stack_slug", "stack_name", "stack_state"},
+			nil),
+		runsNeedingApproval: prometheus.NewDesc(
+			"spacelift_runs_needing_approval",
+			"The number of runs currently needing approval",
+			nil,
+			nil),
+		runsRequiringAttention: prometheus.NewDesc(
+			"spacelift_runs_requiring_attention",
+			"The number of runs requiring attention",
+			nil,
+			nil),
+		driftDetectionSchedulesUpcoming: prometheus.NewDesc(
+			"spacelift_drift_detection_schedules_upcoming",
+			"The number of upcoming drift detection schedules",
+			nil,
+			nil),
 		scrapeDuration: prometheus.NewDesc(
 			"spacelift_scrape_duration_seconds",
 			"The duration in seconds of the request to the Spacelift API for metrics",
@@ -167,6 +329,33 @@ func (c *spaceliftCollector) Describe(descriptorChannel chan<- *prometheus.Desc)
 	descriptorChannel <- c.currentAvgStackSizeByResourceCount
 	descriptorChannel <- c.currentAverageRunDuration
 	descriptorChannel <- c.currentMedianRunDuration
+	descriptorChannel <- c.currentMaxStackSizeByResourceCount
+	descriptorChannel <- c.currentDriftDetectionCoverage
+	descriptorChannel <- c.currentResourcesCountByVendor
+	descriptorChannel <- c.currentHasStacks
+	descriptorChannel <- c.currentHasRuns
+	descriptorChannel <- c.publicUsers
+	descriptorChannel <- c.publicIntentProjects
+	descriptorChannel <- c.publicRunsSchedulable
+	descriptorChannel <- c.workerPoolRunsSchedulable
+	descriptorChannel <- c.workerPoolUsers
+	descriptorChannel <- c.workerPoolNotifications
+	descriptorChannel <- c.workerPoolIntentProjects
+	descriptorChannel <- c.workerPoolDriftDetectionRunLimit
+	descriptorChannel <- c.workerPoolManagedByK8sController
+	descriptorChannel <- c.currentBillingPeriodAllowedSeconds
+	descriptorChannel <- c.currentBillingPeriodAllowedSeats
+	descriptorChannel <- c.currentBillingPeriodUsedSeconds
+	descriptorChannel <- c.currentBillingPeriodUsedWorkers
+	descriptorChannel <- c.seatsLimit
+	descriptorChannel <- c.seatsInUse
+	descriptorChannel <- c.integrationsCount
+	descriptorChannel <- c.auditTrailRetentionDays
+	descriptorChannel <- c.runLogRetentionDays
+	descriptorChannel <- c.largestStackResources
+	descriptorChannel <- c.runsNeedingApproval
+	descriptorChannel <- c.runsRequiringAttention
+	descriptorChannel <- c.driftDetectionSchedulesUpcoming
 	descriptorChannel <- c.buildInfo
 }
 
@@ -177,16 +366,25 @@ type dataPoint struct {
 
 type metricsQuery struct {
 	PublicWorkerPool struct {
-		Parallelism int `graphql:"parallelism"`
-		BusyWorkers int `graphql:"busyWorkers"`
-		PendingRuns int `graphql:"pendingRuns"`
+		Parallelism          int `graphql:"parallelism"`
+		BusyWorkers          int `graphql:"busyWorkers"`
+		PendingRuns          int `graphql:"pendingRuns"`
+		UsersCount           int `graphql:"usersCount"`
+		IntentProjectsCount  int `graphql:"intentProjectsCount"`
+		SchedulableRunsCount int `graphql:"schedulableRunsCount"`
 	} `graphql:"publicWorkerPool"`
 	WorkerPools []struct {
-		ID          string `graphql:"id"`
-		Name        string `graphql:"name"`
-		PendingRuns int    `graphql:"pendingRuns"`
-		BusyWorkers int    `graphql:"busyWorkers"`
-		Workers     []struct {
+		ID                     string `graphql:"id"`
+		Name                   string `graphql:"name"`
+		PendingRuns            int    `graphql:"pendingRuns"`
+		BusyWorkers            int    `graphql:"busyWorkers"`
+		SchedulableRunsCount   int    `graphql:"schedulableRunsCount"`
+		UsersCount             int    `graphql:"usersCount"`
+		NotificationCount      int    `graphql:"notificationCount"`
+		IntentProjectsCount    int    `graphql:"intentProjectsCount"`
+		DriftDetectionRunLimit *int   `graphql:"driftDetectionRunLimit"`
+		ManagedByK8sController bool   `graphql:"managedByK8sController"`
+		Workers                []struct {
 			ID      string `graphql:"id"`
 			Drained bool   `graphql:"drained"`
 		} `graphql:"workers"`
@@ -197,14 +395,88 @@ type metricsQuery struct {
 		UsedPrivateMinutes int `graphql:"usedPrivateMinutes"`
 		UsedPublicMinutes  int `graphql:"usedPublicMinutes"`
 		UsedSeats          int `graphql:"usedSeats"`
+		AllowedMinutes     int `graphql:"allowedMinutes"`
+		AllowedSeats       int `graphql:"allowedSeats"`
+		UsedMinutes        int `graphql:"usedMinutes"`
+		UsedWorkers        int `graphql:"usedWorkers"`
 	} `graphql:"usage"`
-	Metrics struct {
+	Seats struct {
+		User struct {
+			Limit int `graphql:"limit"`
+			InUse int `graphql:"inUse"`
+		} `graphql:"user"`
+		APIKey struct {
+			Limit int `graphql:"limit"`
+			InUse int `graphql:"inUse"`
+		} `graphql:"apiKey"`
+	} `graphql:"seats"`
+	IntegrationsCount struct {
+		AWS                 int `graphql:"aws"`
+		Azure               int `graphql:"azure"`
+		AzureDevOps         int `graphql:"azureDevOps"`
+		Backstage           int `graphql:"backstage"`
+		BitbucketCloud      int `graphql:"bitbucketCloud"`
+		BitbucketDatacenter int `graphql:"bitbucketDatacenter"`
+		Github              int `graphql:"github"`
+		GitLab              int `graphql:"gitlab"`
+		ServiceNow          int `graphql:"serviceNow"`
+		Slack               int `graphql:"slack"`
+		VCSAgentPools       int `graphql:"vcsAgentPools"`
+		Webhooks            int `graphql:"webhooks"`
+		AI                  int `graphql:"ai"`
+	} `graphql:"integrationsCount"`
+	AuditTrailRetentionDays int `graphql:"auditTrailRetentionDays"`
+	RunLogRetentionDays     int `graphql:"runLogRetentionDays"`
+	Metrics                 struct {
 		StacksCountByState          []dataPoint `graphql:"stacksCountByState"`
 		ResourcesCountByDrift       []dataPoint `graphql:"resourcesCountByDrift"`
 		AvgStackSizeByResourceCount []dataPoint `graphql:"avgStackSizeByResourceCount"`
+		MaxStackSizeByResourceCount []dataPoint `graphql:"maxStackSizeByResourceCount"`
 		AverageRunDuration          []dataPoint `graphql:"averageRunDuration"`
 		MedianRunDuration           []dataPoint `graphql:"medianRunDuration"`
+		DriftDetectionCoverage      []dataPoint `graphql:"driftDetectionCoverage"`
+		ResourcesCountByVendor      []dataPoint `graphql:"resourcesCountByVendor"`
+		HasStacks                   bool        `graphql:"hasStacks"`
+		HasRuns                     bool        `graphql:"hasRuns"`
+		LargestStacks               []struct {
+			StackTile struct {
+				Name  string `graphql:"name"`
+				Slug  string `graphql:"slug"`
+				State string `graphql:"state"`
+			} `graphql:"stackTile"`
+			ResourcesCount int `graphql:"resourcesCount"`
+		} `graphql:"largestStacks"`
+		NeedsApprovalRuns []struct {
+			ID string `graphql:"id"`
+		} `graphql:"needsApprovalRuns"`
+		RunsRequiringAttention []struct {
+			ID string `graphql:"id"`
+		} `graphql:"runsRequiringAttention"`
+		UpcomingDriftDetectionSchedules []struct {
+			StackTile struct {
+				Slug string `graphql:"slug"`
+			} `graphql:"stackTile"`
+		} `graphql:"upcomingDriftDetectionSchedules"`
 	} `graphql:"metrics"`
+}
+
+func emitFirstDataPoint(ch chan<- prometheus.Metric, desc *prometheus.Desc, points []dataPoint) {
+	if len(points) > 0 {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, points[0].Value)
+	}
+}
+
+func emitOptionalInt(ch chan<- prometheus.Metric, desc *prometheus.Desc, v *int, labels ...string) {
+	if v != nil {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(*v), labels...)
+	}
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
@@ -245,11 +517,47 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 	metricChannel <- prometheus.MustNewConstMetric(c.publicRunsPending, prometheus.GaugeValue, float64(query.PublicWorkerPool.PendingRuns))
 	metricChannel <- prometheus.MustNewConstMetric(c.publicWorkersBusy, prometheus.GaugeValue, float64(query.PublicWorkerPool.BusyWorkers))
 	metricChannel <- prometheus.MustNewConstMetric(c.publicParallelism, prometheus.GaugeValue, float64(query.PublicWorkerPool.Parallelism))
+	metricChannel <- prometheus.MustNewConstMetric(c.publicUsers, prometheus.GaugeValue, float64(query.PublicWorkerPool.UsersCount))
+	metricChannel <- prometheus.MustNewConstMetric(c.publicIntentProjects, prometheus.GaugeValue, float64(query.PublicWorkerPool.IntentProjectsCount))
+	metricChannel <- prometheus.MustNewConstMetric(c.publicRunsSchedulable, prometheus.GaugeValue, float64(query.PublicWorkerPool.SchedulableRunsCount))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodStart, prometheus.GaugeValue, float64(query.Usage.BillingPeriodStart))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodEnd, prometheus.GaugeValue, float64(query.Usage.BillingPeriodEnd))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedPrivateSeconds, prometheus.GaugeValue, float64(query.Usage.UsedPrivateMinutes*60))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedPublicSeconds, prometheus.GaugeValue, float64(query.Usage.UsedPublicMinutes*60))
 	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedSeats, prometheus.GaugeValue, float64(query.Usage.UsedSeats))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodAllowedSeconds, prometheus.GaugeValue, float64(query.Usage.AllowedMinutes*60))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodAllowedSeats, prometheus.GaugeValue, float64(query.Usage.AllowedSeats))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedSeconds, prometheus.GaugeValue, float64(query.Usage.UsedMinutes*60))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentBillingPeriodUsedWorkers, prometheus.GaugeValue, float64(query.Usage.UsedWorkers))
+
+	metricChannel <- prometheus.MustNewConstMetric(c.seatsLimit, prometheus.GaugeValue, float64(query.Seats.User.Limit), "user")
+	metricChannel <- prometheus.MustNewConstMetric(c.seatsLimit, prometheus.GaugeValue, float64(query.Seats.APIKey.Limit), "api_key")
+	metricChannel <- prometheus.MustNewConstMetric(c.seatsInUse, prometheus.GaugeValue, float64(query.Seats.User.InUse), "user")
+	metricChannel <- prometheus.MustNewConstMetric(c.seatsInUse, prometheus.GaugeValue, float64(query.Seats.APIKey.InUse), "api_key")
+
+	for _, ic := range []struct {
+		label string
+		value int
+	}{
+		{"aws", query.IntegrationsCount.AWS},
+		{"azure", query.IntegrationsCount.Azure},
+		{"azure_devops", query.IntegrationsCount.AzureDevOps},
+		{"backstage", query.IntegrationsCount.Backstage},
+		{"bitbucket_cloud", query.IntegrationsCount.BitbucketCloud},
+		{"bitbucket_datacenter", query.IntegrationsCount.BitbucketDatacenter},
+		{"github", query.IntegrationsCount.Github},
+		{"gitlab", query.IntegrationsCount.GitLab},
+		{"service_now", query.IntegrationsCount.ServiceNow},
+		{"slack", query.IntegrationsCount.Slack},
+		{"vcs_agent_pools", query.IntegrationsCount.VCSAgentPools},
+		{"webhooks", query.IntegrationsCount.Webhooks},
+		{"ai", query.IntegrationsCount.AI},
+	} {
+		metricChannel <- prometheus.MustNewConstMetric(c.integrationsCount, prometheus.GaugeValue, float64(ic.value), ic.label)
+	}
+
+	metricChannel <- prometheus.MustNewConstMetric(c.auditTrailRetentionDays, prometheus.GaugeValue, float64(query.AuditTrailRetentionDays))
+	metricChannel <- prometheus.MustNewConstMetric(c.runLogRetentionDays, prometheus.GaugeValue, float64(query.RunLogRetentionDays))
 
 	for _, state := range query.Metrics.StacksCountByState {
 		if len(state.Labels) > 0 {
@@ -263,17 +571,31 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 		}
 	}
 
-	if len(query.Metrics.AvgStackSizeByResourceCount) > 0 {
-		metricChannel <- prometheus.MustNewConstMetric(c.currentAvgStackSizeByResourceCount, prometheus.GaugeValue, query.Metrics.AvgStackSizeByResourceCount[0].Value)
+	emitFirstDataPoint(metricChannel, c.currentAvgStackSizeByResourceCount, query.Metrics.AvgStackSizeByResourceCount)
+	emitFirstDataPoint(metricChannel, c.currentAverageRunDuration, query.Metrics.AverageRunDuration)
+	emitFirstDataPoint(metricChannel, c.currentMedianRunDuration, query.Metrics.MedianRunDuration)
+	emitFirstDataPoint(metricChannel, c.currentMaxStackSizeByResourceCount, query.Metrics.MaxStackSizeByResourceCount)
+	emitFirstDataPoint(metricChannel, c.currentDriftDetectionCoverage, query.Metrics.DriftDetectionCoverage)
+
+	for _, vendor := range query.Metrics.ResourcesCountByVendor {
+		if len(vendor.Labels) > 0 {
+			metricChannel <- prometheus.MustNewConstMetric(c.currentResourcesCountByVendor, prometheus.GaugeValue, vendor.Value, vendor.Labels[0])
+		}
 	}
 
-	if len(query.Metrics.AverageRunDuration) > 0 {
-		metricChannel <- prometheus.MustNewConstMetric(c.currentAverageRunDuration, prometheus.GaugeValue, query.Metrics.AverageRunDuration[0].Value)
+	metricChannel <- prometheus.MustNewConstMetric(c.currentHasStacks, prometheus.GaugeValue, boolToFloat(query.Metrics.HasStacks))
+	metricChannel <- prometheus.MustNewConstMetric(c.currentHasRuns, prometheus.GaugeValue, boolToFloat(query.Metrics.HasRuns))
+
+	for _, ls := range query.Metrics.LargestStacks {
+		metricChannel <- prometheus.MustNewConstMetric(
+			c.largestStackResources, prometheus.GaugeValue, float64(ls.ResourcesCount),
+			ls.StackTile.Slug, ls.StackTile.Name, ls.StackTile.State,
+		)
 	}
 
-	if len(query.Metrics.MedianRunDuration) > 0 {
-		metricChannel <- prometheus.MustNewConstMetric(c.currentMedianRunDuration, prometheus.GaugeValue, query.Metrics.MedianRunDuration[0].Value)
-	}
+	metricChannel <- prometheus.MustNewConstMetric(c.runsNeedingApproval, prometheus.GaugeValue, float64(len(query.Metrics.NeedsApprovalRuns)))
+	metricChannel <- prometheus.MustNewConstMetric(c.runsRequiringAttention, prometheus.GaugeValue, float64(len(query.Metrics.RunsRequiringAttention)))
+	metricChannel <- prometheus.MustNewConstMetric(c.driftDetectionSchedulesUpcoming, prometheus.GaugeValue, float64(len(query.Metrics.UpcomingDriftDetectionSchedules)))
 
 	for _, workerPool := range query.WorkerPools {
 		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolRunsPending, prometheus.GaugeValue, float64(workerPool.PendingRuns), workerPool.ID, workerPool.Name)
@@ -287,5 +609,12 @@ func (c *spaceliftCollector) Collect(metricChannel chan<- prometheus.Metric) {
 			}
 		}
 		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolWorkersDrained, prometheus.GaugeValue, float64(drained), workerPool.ID, workerPool.Name)
+		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolRunsSchedulable, prometheus.GaugeValue, float64(workerPool.SchedulableRunsCount), workerPool.ID, workerPool.Name)
+		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolUsers, prometheus.GaugeValue, float64(workerPool.UsersCount), workerPool.ID, workerPool.Name)
+		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolNotifications, prometheus.GaugeValue, float64(workerPool.NotificationCount), workerPool.ID, workerPool.Name)
+		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolIntentProjects, prometheus.GaugeValue, float64(workerPool.IntentProjectsCount), workerPool.ID, workerPool.Name)
+
+		emitOptionalInt(metricChannel, c.workerPoolDriftDetectionRunLimit, workerPool.DriftDetectionRunLimit, workerPool.ID, workerPool.Name)
+		metricChannel <- prometheus.MustNewConstMetric(c.workerPoolManagedByK8sController, prometheus.GaugeValue, boolToFloat(workerPool.ManagedByK8sController), workerPool.ID, workerPool.Name)
 	}
 }


### PR DESCRIPTION
Update to add missing metrics for point-in-time fields available from the Spacelift GraphQL metrics endpoint.

 Purposely omitted Dora metrics and calculating range metrics in favor of following Prometheus conventions.

- Public and per-pool worker pool fields (pending/busy/parallelism, workers, drained workers, schedulable runs, users, notifications, intent projects, drift-detection run limit, k8s-controller flag)
- Billing usage (allowed/used seconds and seats, used workers)
- Seats limit/in-use 
- Integrations count by integration type
- Audit-trail and run-log retention days
- Stack/run/drift breakdowns: stacks-by-state, resources-by-drift, resources-by-vendor, avg/max stack size, avg/median run duration, drift-detection coverage, largest stacks, has_stacks/has_runs
- Current-state queues: runs needing approval, runs requiring attention, upcoming drift-detection schedules