### PR TITLE
Support reading API secret values from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ the format `https://<account>.app.spacelift.io`, for example `https://my-account
 **NOTE:** the API key you use must be an Admin key because some of the API fields used for the metrics
 require administrative access.
 
+#### OIDC API keys with rotating secrets
+
+If your API key is configured for OIDC (the key ID has the form `oidc::<issuer>::<key-id>`), the
+"secret" is an OIDC JWT issued by your identity provider rather than a static string. Use
+`--api-key-secret-file` (or `SPACELIFT_PROMEX_API_KEY_SECRET_FILE`) to point at the file that holds
+the token. The file is re-read on every token refresh, so projected Kubernetes service-account
+tokens that rotate on disk are picked up automatically without restarting the exporter.
+
 ### Running via the Binary
 
 Download the exporter binary from our
@@ -150,7 +158,8 @@ OPTIONS:
    --api-endpoint value, -e value    Your spacelift API endpoint (e.g. https://myaccount.app.spacelift.io) [$SPACELIFT_PROMEX_API_ENDPOINT]
    --ca-cert-path value              Path to a PEM-encoded CA certificate to trust in addition to system certificates [$SPACELIFT_PROMEX_CA_CERT_PATH]
    --api-key-id value, -k value      Your spacelift API key ID [$SPACELIFT_PROMEX_API_KEY_ID]
-   --api-key-secret value, -s value  Your spacelift API key secret [$SPACELIFT_PROMEX_API_KEY_SECRET]
+   --api-key-secret value, -s value  Your spacelift API key secret. Mutually exclusive with --api-key-secret-file. [$SPACELIFT_PROMEX_API_KEY_SECRET]
+   --api-key-secret-file value       Path to a file containing the spacelift API key secret. The file is re-read on every token refresh, so this is the right choice for rotating secrets such as Kubernetes projected service-account tokens used with OIDC API keys. Mutually exclusive with --api-key-secret. [$SPACELIFT_PROMEX_API_KEY_SECRET_FILE]
    --is-development, -d              Uses settings appropriate during local development (default: false) [$SPACELIFT_PROMEX_IS_DEVELOPMENT]
    --listen-address value, -l value  The address to listen on for HTTP requests (default: ":9953") [$SPACELIFT_PROMEX_LISTEN_ADDRESS]
    --scrape-timeout value, -t value  The maximum duration to wait for a response from the Spacelift API during scraping (default: 5s) [$SPACELIFT_PROMEX_SCRAPE_TIMEOUT]

--- a/client/session/api_key.go
+++ b/client/session/api_key.go
@@ -9,17 +9,38 @@ import (
 	"github.com/hasura/go-graphql-client"
 )
 
+// SecretProvider returns the API key secret to use when exchanging credentials
+// for a bearer token. It is invoked on every token exchange, allowing callers
+// to supply rotating secrets such as projected Kubernetes service-account
+// tokens used with Spacelift's OIDC API keys.
+type SecretProvider func() (string, error)
+
+// StaticSecret wraps a fixed secret in a SecretProvider.
+func StaticSecret(secret string) SecretProvider {
+	return func() (string, error) { return secret, nil }
+}
+
 // FromAPIKey builds a Spacelift session from a combination of endpoint, API key
-// ID and API key secret.
+// ID and a static API key secret.
 func FromAPIKey(ctx context.Context, client *http.Client, endpoint, keyID, keySecret string) (Session, error) {
+	return FromAPIKeyProvider(ctx, client, endpoint, keyID, StaticSecret(keySecret))
+}
+
+// FromAPIKeyProvider builds a Spacelift session that resolves the API key
+// secret through the provider on every token exchange.
+func FromAPIKeyProvider(ctx context.Context, client *http.Client, endpoint, keyID string, secret SecretProvider) (Session, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("API key secret provider must not be nil")
+	}
+
 	out := &apiKey{
 		apiToken: apiToken{
 			client:   client,
 			endpoint: endpoint,
 			timer:    time.Now,
 		},
-		keyID:     keyID,
-		keySecret: keySecret,
+		keyID:  keyID,
+		secret: secret,
 	}
 
 	if err := out.exchange(ctx); err != nil {
@@ -31,7 +52,8 @@ func FromAPIKey(ctx context.Context, client *http.Client, endpoint, keyID, keySe
 
 type apiKey struct {
 	apiToken
-	keyID, keySecret string
+	keyID  string
+	secret SecretProvider
 }
 
 func (g *apiKey) BearerToken(ctx context.Context) (string, error) {
@@ -49,13 +71,18 @@ func (g *apiKey) RefreshToken(ctx context.Context) error {
 }
 
 func (g *apiKey) exchange(ctx context.Context) error {
+	secret, err := g.secret()
+	if err != nil {
+		return fmt.Errorf("could not resolve API key secret: %w", err)
+	}
+
 	var mutation struct {
 		APIKeyUser user `graphql:"apiKeyUser(id: $id, secret: $secret)"`
 	}
 
 	variables := map[string]interface{}{
 		"id":     graphql.ID(g.keyID),
-		"secret": graphql.String(g.keySecret),
+		"secret": graphql.String(secret),
 	}
 
 	if err := g.mutate(ctx, &mutation, variables); err != nil {

--- a/client/session/new.go
+++ b/client/session/new.go
@@ -7,10 +7,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// New creates a session using the default chain of credentials sources:
-// first the environment, then the current credentials file.
+// New creates a session from a static API key ID and secret.
 func New(ctx context.Context, client *http.Client, endpoint, keyID, keySecret string) (Session, error) {
-	session, err := FromAPIKey(ctx, client, endpoint, keyID, keySecret)
+	return NewWithSecretProvider(ctx, client, endpoint, keyID, StaticSecret(keySecret))
+}
+
+// NewWithSecretProvider creates a session whose API key secret is resolved
+// through the provider on every token refresh. This lets callers supply a
+// secret that rotates on disk (for example, a Kubernetes projected
+// service-account token used with a Spacelift OIDC API key).
+func NewWithSecretProvider(ctx context.Context, client *http.Client, endpoint, keyID string, secret SecretProvider) (Session, error) {
+	session, err := FromAPIKeyProvider(ctx, client, endpoint, keyID, secret)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create session from Spacelift API key")
 	}

--- a/serve_command.go
+++ b/serve_command.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,10 +65,19 @@ var (
 	flagAPIKeySecret = &cli.StringFlag{
 		Name:        "api-key-secret",
 		Aliases:     []string{"s"},
-		Usage:       "Your spacelift API key secret",
+		Usage:       "Your spacelift API key secret. Mutually exclusive with --api-key-secret-file.",
 		Sources:     cli.EnvVars("SPACELIFT_PROMEX_API_KEY_SECRET"),
-		Required:    true,
 		Destination: &apiKeySecret,
+	}
+
+	apiKeySecretFile     string
+	flagAPIKeySecretFile = &cli.StringFlag{
+		Name: "api-key-secret-file",
+		Usage: "Path to a file containing the spacelift API key secret. The file is re-read on every " +
+			"token refresh, so this is the right choice for rotating secrets such as Kubernetes " +
+			"projected service-account tokens used with OIDC API keys. Mutually exclusive with --api-key-secret.",
+		Sources:     cli.EnvVars("SPACELIFT_PROMEX_API_KEY_SECRET_FILE"),
+		Destination: &apiKeySecretFile,
 	}
 
 	isDevelopment     bool
@@ -99,6 +109,7 @@ var serveCommand *cli.Command = &cli.Command{
 		flagCACertPath,
 		flagAPIKeyID,
 		flagAPIKeySecret,
+		flagAPIKeySecretFile,
 		flagIsDevelopment,
 		flagScrapeTimeout,
 	},
@@ -114,6 +125,11 @@ var serveCommand *cli.Command = &cli.Command{
 			return cli.Exit(fmt.Sprintf("api-endpoint %q does not seem to be a valid URL", apiEndpoint), ExitCodeStartupError)
 		}
 
+		secretProvider, err := buildSecretProvider(apiKeySecret, apiKeySecretFile)
+		if err != nil {
+			return cli.Exit(err.Error(), ExitCodeStartupError)
+		}
+
 		httpClient, err := newHTTPClient(caCertPath)
 		if err != nil {
 			return cli.Exit(fmt.Sprintf("could not configure HTTP client: %v", err), ExitCodeStartupError)
@@ -124,7 +140,7 @@ var serveCommand *cli.Command = &cli.Command{
 		session, err := func() (session.Session, error) {
 			sessionCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 			defer cancel()
-			return session.New(sessionCtx, httpClient, apiEndpoint, apiKeyID, apiKeySecret)
+			return session.NewWithSecretProvider(sessionCtx, httpClient, apiEndpoint, apiKeyID, secretProvider)
 		}()
 		if err != nil {
 			logger.Fatalw("failed to create Spacelift API session", zap.Error(err))
@@ -224,4 +240,41 @@ func newHTTPClient(caCertPath string) (*http.Client, error) {
 	}
 
 	return &http.Client{Transport: transport}, nil
+}
+
+// buildSecretProvider returns a SecretProvider derived from exactly one of the
+// two CLI inputs. The file-backed provider re-reads its file on every
+// invocation so that rotating tokens (e.g. Kubernetes projected
+// service-account tokens) are picked up automatically.
+func buildSecretProvider(secret, secretFile string) (session.SecretProvider, error) {
+	switch {
+	case secret != "" && secretFile != "":
+		return nil, fmt.Errorf("--api-key-secret and --api-key-secret-file are mutually exclusive")
+	case secret == "" && secretFile == "":
+		return nil, fmt.Errorf("one of --api-key-secret or --api-key-secret-file is required")
+	case secretFile != "":
+		path := filepath.Clean(secretFile)
+		// Read once up front so misconfigurations fail fast at startup
+		// rather than on the first token refresh.
+		if _, err := readSecretFile(path); err != nil {
+			return nil, err
+		}
+		return func() (string, error) { return readSecretFile(path) }, nil
+	default:
+		return session.StaticSecret(secret), nil
+	}
+}
+
+func readSecretFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("could not read API key secret from %q: %w", path, err)
+	}
+
+	secret := strings.TrimSpace(string(data))
+	if secret == "" {
+		return "", fmt.Errorf("API key secret file %q is empty", path)
+	}
+
+	return secret, nil
 }

--- a/serve_command.go
+++ b/serve_command.go
@@ -108,10 +108,17 @@ var serveCommand *cli.Command = &cli.Command{
 		flagAPIEndpoint,
 		flagCACertPath,
 		flagAPIKeyID,
-		flagAPIKeySecret,
-		flagAPIKeySecretFile,
 		flagIsDevelopment,
 		flagScrapeTimeout,
+	},
+	MutuallyExclusiveFlags: []cli.MutuallyExclusiveFlags{
+		{
+			Required: true,
+			Flags: [][]cli.Flag{
+				{flagAPIKeySecret},
+				{flagAPIKeySecretFile},
+			},
+		},
 	},
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		ctx = logging.Init(ctx, isDevelopment)


### PR DESCRIPTION
This is necessary for leveraging OIDC-based API tokens on platforms like Kubernetes, where the JWT is exposed as an auto-updating file (e.g. [`/var/run/secrets/kubernetes.io/serviceaccount/token`](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/)). Passing the JWT as a static key requires restarting promex when the key rotates, which is not friendly to operators. Pointing promex to a file allows promex to run indefinitely (since it will pick up the new JWT when rotation occurs).